### PR TITLE
Update imports for DP3 6.0

### DIFF
--- a/dp3_helpers/polconv.py
+++ b/dp3_helpers/polconv.py
@@ -7,14 +7,6 @@ Or you save this python file somewhere you like and run:
 export PYTHONPATH=/somewhere/you/like:$PYTHONPATH
 
 """
-
-try:
-    from dppp import DPStep as Step
-    DP3name = 'DPPP' # default
-except:
-    from dp3 import Step
-    DP3name = 'DP3'
-
 from subprocess import check_output
 import re
 import numpy as np
@@ -31,6 +23,16 @@ except AttributeError:
 
 if DP3_VERSION > 5.3:
     from dp3 import Fields
+
+try:
+    from dppp import DPStep as Step
+    DP3name = 'DPPP' # default
+except:
+    if DP3_VERSION >= 6:
+        from dp3.pydp3 import Step
+    else:
+        from dp3 import Step
+    DP3name = 'DP3'
 
 class PolConv(Step):
     """

--- a/dp3_helpers/polconv.py
+++ b/dp3_helpers/polconv.py
@@ -10,9 +10,13 @@ export PYTHONPATH=/somewhere/you/like:$PYTHONPATH
 from subprocess import check_output
 import re
 import numpy as np
+import shutil
 import sys
 
 #hacky way to figure out the DPPP/DP3 version (important to run this script properly)
+DP3name = shutil.which('DP3')
+if not DP3name:
+    DP3name = shutil.which('DPPP')
 try:
     rgx = '[0-9]+(\.[0-9]+)+'
     grep_version_string = str(check_output(DP3name+' --version', shell=True), 'utf-8')
@@ -26,13 +30,11 @@ if DP3_VERSION > 5.3:
 
 try:
     from dppp import DPStep as Step
-    DP3name = 'DPPP' # default
 except:
     if DP3_VERSION >= 6:
         from dp3.pydp3 import Step
     else:
         from dp3 import Step
-    DP3name = 'DP3'
 
 class PolConv(Step):
     """


### PR DESCRIPTION
`PythonStep` has been overhauled in DP3 6.0. A new column isn't written unless I use `from dp3.pyd3p import Step` instead of `from dp3 import Step`. This adds a check for this.