### PR TITLE
Reduce memory footprint of lin<->circ conversions

### DIFF
--- a/h5_merger.py
+++ b/h5_merger.py
@@ -2255,10 +2255,10 @@ class PolChange:
 
         # Performance hit for small H5parms, so prefer to stay in RAM.
         if MEM_NEEDED < MEM_AVAIL:
-            G_new = zeros(G.shape[0:-1] + (4,)).astype(complex128)
+            G_new = zeros(G_SHAPE).astype(complex128)
         else:
             print("H5parm too large for in-memory conversion. Using memory-mapped approach.")
-            G_new = memmap("tempG_new.dat", dtype=complex128, mode="w+", shape=G.shape[0:-1] + (4,))
+            G_new = memmap("tempG_new.dat", dtype=complex128, mode="w+", shape=G_SHAPE)
 
         G_new[..., 0] = (G[..., 0] + G[..., -1])
         G_new[..., 1] = (G[..., 0] - G[..., -1])

--- a/h5_merger.py
+++ b/h5_merger.py
@@ -18,7 +18,7 @@ from glob import glob
 from losoto.h5parm import h5parm
 from losoto.lib_operations import reorderAxes
 from numpy import zeros, ones, round, unique, array_equal, append, where, isfinite, complex128, expand_dims, \
-    pi, array, all, exp, angle, sort, sum, finfo, take, diff, equal, take, transpose, cumsum, insert, abs, asarray, newaxis, argmin, cos, sin, float32
+    pi, array, all, exp, angle, sort, sum, finfo, take, diff, equal, take, transpose, cumsum, insert, abs, asarray, newaxis, argmin, cos, sin, float32, memmap
 import os
 import re
 from scipy.interpolate import interp1d
@@ -2246,7 +2246,7 @@ class PolChange:
         :return: Circular polarized Gain
         """
 
-        G_new = zeros(G.shape[0:-1] + (4,)).astype(complex128)
+        G_new = memmap("tempG_new.dat", dtype=complex128, mode="w+", shape=G.shape[0:-1] + (4,))
 
         G_new[..., 0] = (G[..., 0] + G[..., -1])
         G_new[..., 1] = (G[..., 0] - G[..., -1])

--- a/h5_merger.py
+++ b/h5_merger.py
@@ -2246,29 +2246,20 @@ class PolChange:
         :return: Circular polarized Gain
         """
 
-        RR = (G[..., 0] + G[..., -1])
-        RL = (G[..., 0] - G[..., -1])
-        LR = (G[..., 0] - G[..., -1])
-        LL = (G[..., 0] + G[..., -1])
-
-        if G.shape[-1] == 4:
-            RR += 1j * (G[..., 2] - G[..., 1])
-            RL += 1j * (G[..., 2] + G[..., 1])
-            LR -= 1j * (G[..., 2] + G[..., 1])
-            LL += 1j * (G[..., 1] - G[..., 2])
-
-        RR /= 2
-        RL /= 2
-        LR /= 2
-        LL /= 2
-
         G_new = zeros(G.shape[0:-1] + (4,)).astype(complex128)
 
-        G_new[..., 0] += RR
-        G_new[..., 1] += RL
-        G_new[..., 2] += LR
-        G_new[..., 3] += LL
+        G_new[..., 0] = (G[..., 0] + G[..., -1])
+        G_new[..., 1] = (G[..., 0] - G[..., -1])
+        G_new[..., 2] = (G[..., 0] - G[..., -1])
+        G_new[..., 3] = (G[..., 0] + G[..., -1])
 
+        if G.shape[-1] == 4:
+            G_new[..., 0] += 1j * (G[..., 2] - G[..., 1])
+            G_new[..., 1] += 1j * (G[..., 2] + G[..., 1])
+            G_new[..., 2] -= 1j * (G[..., 2] + G[..., 1])
+            G_new[..., 3] += 1j * (G[..., 1] - G[..., 2])
+
+        G_new /= 2
         G_new[abs(G_new) < 10 * finfo(float).eps] = 0
 
         return G_new

--- a/h5_merger.py
+++ b/h5_merger.py
@@ -2298,10 +2298,10 @@ class PolChange:
 
         # Performance hit for small H5parms, so prefer to stay in RAM.
         if MEM_NEEDED < MEM_AVAIL:
-            G_new = zeros(G.shape[0:-1] + (4,)).astype(complex128)
+            G_new = zeros(G_SHAPE).astype(complex128)
         else:
             print("H5parm too large for in-memory conversion. Using memory-mapped approach.")
-            G_new = memmap("tempG_new.dat", dtype=complex128, mode="w+", shape=G.shape[0:-1] + (4,))
+            G_new = memmap("tempG_new.dat", dtype=complex128, mode="w+", shape=G_SHAPE)
 
         G_new[..., 0] = (G[..., 0] + G[..., -1])
         G_new[..., 1] = 1j * (G[..., 0] - G[..., -1])

--- a/h5_merger.py
+++ b/h5_merger.py
@@ -2269,7 +2269,7 @@ class PolChange:
         G_new[..., 2] += LR
         G_new[..., 3] += LL
 
-        G_new = where(abs(G_new) < 10 * finfo(float).eps, 0, G_new)
+        G_new[abs(G_new) < 10 * finfo(float).eps] = 0
 
         return G_new
 


### PR DESCRIPTION
I had a ~7 GB h5parm that couldn't quite fit on my laptop for conversion from linear to circular, using over 40 GB before being killed. After some fiddling, I found some potential optimisations to reduce the memory footprint, after which it could just about fit on my laptop's RAM:
![Screenshot from 2024-09-12 11-34-40](https://github.com/user-attachments/assets/92393429-c952-4869-aad5-9a0d72dc3563)

This MR implements the following optimisations:
- Avoid numpy where statement.
- Assign directly to G_new to avoid extra copies of data.
- Memory-mapping when the conversion won't fit in RAM (might not be optimal compared to say looping in chunks?).